### PR TITLE
Fix GORM tag formatting for Task ID field in database model

### DIFF
--- a/task-queue-system/internal/database/database.go
+++ b/task-queue-system/internal/database/database.go
@@ -17,7 +17,7 @@ var DB *gorm.DB
 // Each field is mapped to a column in the 'tasks' table.
 type Task struct {
 	// ID is the unique identifier for the task, a UUID generated on creation.
-	ID uuid.UUID `gorm:"type:uuid,primary_key;"`
+	ID uuid.UUID `gorm:"type:uuid;primary_key;"`
 
 	// Type is a string that identifies the kind of task (e.g., "send_email").
 	Type string

--- a/task-queue-system/internal/database/database.go
+++ b/task-queue-system/internal/database/database.go
@@ -17,7 +17,7 @@ var DB *gorm.DB
 // Each field is mapped to a column in the 'tasks' table.
 type Task struct {
 	// ID is the unique identifier for the task, a UUID generated on creation.
-	ID uuid.UUID `gorm:"type:uuid;primary_key;"`
+	ID uuid.UUID `gorm:"type:uuid;primaryKey;"`
 
 	// Type is a string that identifies the kind of task (e.g., "send_email").
 	Type string


### PR DESCRIPTION
Correct the GORM tag formatting for the Task ID field to ensure proper database mapping.